### PR TITLE
Add Pull Request Badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,10 @@
 
 * [github-issue-templates](https://github.com/stevemao/github-issue-templates)
 
+## :toolbox: Tools
+
+* [Pull Request Badge](https://pullrequestbadge.com/) Programatically insert badges in your pull request descriptions and then link them to anything.
+
 ## :pencil: License
 
 [Public Domain](https://creativecommons.org/publicdomain/zero/1.0/), [Zeno Rocha](https://github.com/zenorocha)


### PR DESCRIPTION
Hi, not sure  if this meets the criteria to get merged, but at least the tool is somewhat related. 

[Pull Request Badge](https://pullrequestbadge.com/) is a GitHub App that lets you programatically insert badges in your pull request descriptions and then link them to anything.

<img src="https://user-images.githubusercontent.com/1393946/92336561-4d45a700-f0a2-11ea-9c48-913f913fc856.png" width="400" />
